### PR TITLE
Add support for plain text URL fields along with link fields.

### DIFF
--- a/src/Plugin/DataSource/Vocabulary.php
+++ b/src/Plugin/DataSource/Vocabulary.php
@@ -39,6 +39,11 @@ class Vocabulary implements AutocompleteEndpointDataSourceInterface {
           if (array_key_exists('uri', $uri[0]) && !is_null($uri[0]['uri'])) {
             $results[] = ['label' => $term->name, 'uri' => $uri[0]['uri']];
           }
+          else if (array_key_exists('value', $uri[0]) && !is_null($uri[0]['value'])) {
+
+            $results[] = ['label' => $term->name, 'uri' => $uri[0]['value']];
+          }
+
         }
       }
     }


### PR DESCRIPTION
The Vocabulary.php is getting a 'uri' value out of the term that holds the value, but the documentation says it can use plain text fields.

Adding a check to also look for 'value' elements in the array.